### PR TITLE
Add support for 48 FPS

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 ## Features
 
-- supports 23.98, 24, 25, 29.97, 30, 50, 59.94, 60 fps and msec
+- supports 23.98, 24, 25, 29.97, 30, 48, 50, 59.94, 60 fps and msec
 - supports drop-frame and non-drop-frame codes
 - instantiate timecodes from frame count, string time code
 - (WIP)timecode arithmetics: adding frame counts and other timecodes

--- a/Timecode4net.Tests/TimeCodeTests.cs
+++ b/Timecode4net.Tests/TimeCodeTests.cs
@@ -57,6 +57,7 @@ namespace Timecode4net.Tests
             new object[] {1800, FrameRate.fps24, false, "00:01:15:00"},
             new object[] {1800, FrameRate.fps25, false, "00:01:12:00"},
             new object[] {1800, FrameRate.fps30, false, "00:01:00:00"},
+            new object[] {1800, FrameRate.fps48, false, "00:00:37:24"},
             new object[] {1800, FrameRate.fps50, false, "00:00:36:00"},
             new object[] {1800, FrameRate.fps60, false, "00:00:30:00"}
         };

--- a/Timecode4net/Enums.cs
+++ b/Timecode4net/Enums.cs
@@ -26,6 +26,10 @@ namespace Timecode4net
         /// </summary>
         fps30,
         /// <summary>
+        ///     SMPTE 30frames/sec.
+        /// </summary>
+        fps48,
+        /// <summary>
         ///     SMPTE 50frames/sec.
         /// </summary>
         fps50,

--- a/Timecode4net/Extensions.cs
+++ b/Timecode4net/Extensions.cs
@@ -16,6 +16,8 @@ namespace Timecode4net
                 case FrameRate.fps29_97:
                 case FrameRate.fps30:
                     return 30;
+                case FrameRate.fps48:
+                    return 48;
                 case FrameRate.fps50:
                     return 50;
                 case FrameRate.fps59_94:
@@ -42,6 +44,8 @@ namespace Timecode4net
                     return 29.97;
                 case FrameRate.fps30:
                     return 30;
+                case FrameRate.fps48:
+                    return 48;
                 case FrameRate.fps50:
                     return 50;
                 case FrameRate.fps59_94:


### PR DESCRIPTION
Add support for 48 FPS, a valid frame rate for Digital Cinema IOP DCPs