### PR TITLE
Replace ToInt with ToDouble in Timecode.ToTimeSpan method

### DIFF
--- a/Timecode4net/Extensions.cs
+++ b/Timecode4net/Extensions.cs
@@ -32,7 +32,7 @@ namespace Timecode4net
                 FrameRate.fps50 => 50,
                 FrameRate.fps59_94 => 60000 / 1001d,
                 FrameRate.fps60 => 60,
-                FrameRate.msec => 1,
+                FrameRate.msec => 1000,
                 _ => throw new ArgumentOutOfRangeException(nameof(frameRate), frameRate, null)
             };
         }

--- a/Timecode4net/Extensions.cs
+++ b/Timecode4net/Extensions.cs
@@ -19,21 +19,6 @@ namespace Timecode4net
             };
         }
 
-        public static long ToLong(this FrameRate frameRate)
-        {
-            return frameRate switch
-            {
-                FrameRate.fps23_98 or FrameRate.fps24 => 24l,
-                FrameRate.fps25 => 25l,
-                FrameRate.fps29_97 or FrameRate.fps30 => 30l,
-                FrameRate.fps48 => 48l,
-                FrameRate.fps50 => 50l,
-                FrameRate.fps59_94 or FrameRate.fps60 => 60l,
-                FrameRate.msec => 1000l,
-                _ => throw new ArgumentOutOfRangeException(nameof(frameRate), frameRate, null)
-            };
-        }
-
         public static double ToDouble(this FrameRate frameRate)
         {
             return frameRate switch

--- a/Timecode4net/Extensions.cs
+++ b/Timecode4net/Extensions.cs
@@ -19,6 +19,21 @@ namespace Timecode4net
             };
         }
 
+        public static long ToLong(this FrameRate frameRate)
+        {
+            return frameRate switch
+            {
+                FrameRate.fps23_98 or FrameRate.fps24 => 24l,
+                FrameRate.fps25 => 25l,
+                FrameRate.fps29_97 or FrameRate.fps30 => 30l,
+                FrameRate.fps48 => 48l,
+                FrameRate.fps50 => 50l,
+                FrameRate.fps59_94 or FrameRate.fps60 => 60l,
+                FrameRate.msec => 1000l,
+                _ => throw new ArgumentOutOfRangeException(nameof(frameRate), frameRate, null)
+            };
+        }
+
         public static double ToDouble(this FrameRate frameRate)
         {
             return frameRate switch

--- a/Timecode4net/Timecode.cs
+++ b/Timecode4net/Timecode.cs
@@ -79,6 +79,8 @@ namespace Timecode4net
 
         private readonly int _frameRate;
 
+        public FrameRate FrameRate => _rawFrameRate;
+
         public int TotalFrames { get; private set; }
     
         public int Hours { get; private set; }

--- a/Timecode4net/Timecode.cs
+++ b/Timecode4net/Timecode.cs
@@ -113,7 +113,7 @@ namespace Timecode4net
 
         public TimeSpan ToTimeSpan()
         {
-            var framesInMsec = this.TotalFrames * FrameRate.msec.ToLong() / this._rawFrameRate.ToDouble();
+            var framesInMsec = this.TotalFrames * FrameRate.msec.ToDouble() / this._rawFrameRate.ToDouble();
             return TimeSpan.FromMilliseconds(framesInMsec);
         }
 

--- a/Timecode4net/Timecode.cs
+++ b/Timecode4net/Timecode.cs
@@ -111,7 +111,7 @@ namespace Timecode4net
 
         public TimeSpan ToTimeSpan()
         {
-            var framesInMsec = this.TotalFrames * FrameRate.msec.ToInt() / this._rawFrameRate.ToDouble();
+            var framesInMsec = this.TotalFrames * FrameRate.msec.ToLong() / this._rawFrameRate.ToDouble();
             return TimeSpan.FromMilliseconds(framesInMsec);
         }
 


### PR DESCRIPTION
Fix overflow error for high timecodes, i.e. 23:59:59:00 for 25 fps.
TotalFrames * 1000 exceeds int capabilities
